### PR TITLE
Add SAP HANA connection example

### DIFF
--- a/SAP_HANA_Connection.bas
+++ b/SAP_HANA_Connection.bas
@@ -1,6 +1,11 @@
 Attribute VB_Name = "SAP_HANA_Connection"
 Option Explicit
 
+' Wraps value in braces and escapes closing braces for ODBC connection strings.
+Private Function EscapeOdbc(ByVal value As String) As String
+    EscapeOdbc = "{" & Replace(value, "}", "}}") & "}"
+End Function
+
 ' Establishes a connection to SAP HANA and executes a query.
 ' Requires reference: Tools > References > Microsoft ActiveX Data Objects x.x Library.
 
@@ -17,8 +22,8 @@ Public Function OpenHanaConnection( _
     ' DSN-less connection string for SAP HANA.
     ' Use HDBODBC32 for 32-bit Office installations.
     conn.ConnectionString = _
-        "Driver={HDBODBC};ServerNode=" & ServerNode & _
-        ";UID=" & UserName & ";PWD=" & Password
+        "Driver={HDBODBC};ServerNode=" & EscapeOdbc(ServerNode) & _
+        ";UID=" & EscapeOdbc(UserName) & ";PWD=" & EscapeOdbc(Password)
 
     conn.Open
     Set OpenHanaConnection = conn


### PR DESCRIPTION
## Summary
- allow passing server node, user name, and password into GetHanaData
- document how to supply credentials in the example and README
- escape credentials in the connection string so semicolons and closing braces are handled correctly

## Testing
- `rg -n "GetHanaData" SAP_HANA_Connection.bas`


------
https://chatgpt.com/codex/tasks/task_e_68bbbfe57ec88326acec39e2bb44b3a0